### PR TITLE
feat: pr label, issue label commands

### DIFF
--- a/packages/relgen-core/src/index.ts
+++ b/packages/relgen-core/src/index.ts
@@ -372,7 +372,7 @@ const relgen = ({
             num: number;
           },
           options?: {
-            write?: 'additive' | 'replacing' | false;
+            write?: 'add' | 'set' | false;
             exclude?: 'existing' | string[];
             prompt?: string;
           }
@@ -501,7 +501,7 @@ const relgen = ({
               repo,
               issue_number: num,
               labels:
-                options.write === 'replacing'
+                options.write === 'set'
                   ? result.object.labels
                   : unique([...pr.data.labels, ...result.object.labels]),
             });
@@ -518,7 +518,7 @@ const relgen = ({
             num: number;
           },
           options?: {
-            write?: 'additive' | 'replacing' | false;
+            write?: 'add' | 'set' | false;
             exclude?: 'existing' | string[];
             prompt?: string;
           }
@@ -604,7 +604,7 @@ const relgen = ({
               repo,
               issue_number: num,
               labels:
-                options.write === 'replacing'
+                options.write === 'set'
                   ? result.object.labels
                   : unique([...issue.data.labels, ...result.object.labels]),
             });


### PR DESCRIPTION
### Changes
This pull request introduces new commands for labeling issues and pull requests in the CLI tool. It adds the ability to label both issues and pull requests with options to add or set labels, as well as exclude existing labels.

### Implementation
The implementation includes new functions to parse issue and pull request URLs, and commands to handle labeling. The `label` command for both issues and pull requests allows users to specify the action (add or set) and to exclude existing labels. The code also refactors the existing parsing logic to be reused for both issues and pull requests.