### PR TITLE
feat: support non-latest release notes

### DIFF
--- a/apps/relgen/src/index.ts
+++ b/apps/relgen/src/index.ts
@@ -214,8 +214,9 @@ issue
     }
   });
 
+// Can be e.g. zlalvani/relgen or https://github.com/zlalvani/relgen
 const parseRepoPath = (path: string) => {
-  const [owner, repo] = path.split('/').slice(-2);
+  const [owner, repo] = path.split('/').filter(Boolean).slice(-2);
 
   if (!owner || !repo) {
     throw new Error('Invalid repository URL');
@@ -230,7 +231,9 @@ const release = remote
 
 release
   .command('describe')
-  .argument('<repo>', 'repository or specific release')
+  .argument('<repo>', 'repository')
+  .option('--from <from>', 'tag of the previous release', 'latest' as const)
+  .option('--to <to>', 'tag of the current release')
   .addOption(
     new Option('--persona <persona>', 'persona').choices([
       'marketing',
@@ -251,11 +254,7 @@ release
   )
   .description('describe a release')
   .action(async (repoOrReleasePath, options) => {
-    // TODO: support existing release summaries
-    if (repoOrReleasePath.includes('/release/')) {
-      throw new Error('Not implemented');
-    }
-
+    const { from, to } = options;
     const { owner, repo } = parseRepoPath(repoOrReleasePath);
 
     const {
@@ -290,6 +289,8 @@ release
       {
         owner,
         repo,
+        fromTag: from,
+        toTag: to,
       },
       {
         include,

--- a/packages/relgen-core/src/clients/github.ts
+++ b/packages/relgen-core/src/clients/github.ts
@@ -43,7 +43,9 @@ export const githubClient = (octo: Octokit) => {
           };
           type?: 'issue' | 'pr';
           status?: 'open' | 'closed' | 'merged';
+          base?: string;
           mergedAfter?: Date;
+          mergedBefore?: Date;
         }) => {
           const filters: string[] = [];
 
@@ -61,6 +63,14 @@ export const githubClient = (octo: Octokit) => {
 
           if (query.mergedAfter) {
             filters.push(`merged:>${query.mergedAfter.toISOString()}`);
+          }
+
+          if (query.mergedBefore) {
+            filters.push(`merged:<${query.mergedBefore.toISOString()}`);
+          }
+
+          if (query.base) {
+            filters.push(`base:${query.base}`);
           }
 
           const q = filters.join(' ');

--- a/packages/relgen-core/src/services/llm.ts
+++ b/packages/relgen-core/src/services/llm.ts
@@ -52,7 +52,7 @@ export const languageModelService = (
           }
           case 'product': {
             system = dedent`
-            You are a highly experienced product manager tasked with summarizing the latest release for .
+            You are a highly experienced product manager tasked with summarizing the latest release for the rest of the product org.
             Use the given context to generate a summary that will be used in a product update.
             Use proper English grammar and punctuation like a native speaker.
             Keep your output concise and relevant.


### PR DESCRIPTION
### Changes
- Added support for specifying non-latest release notes by introducing `--from` and `--to` options in the command line interface.
- Updated the `parseRepoPath` function to handle repository paths more robustly.
- Modified the GitHub client to allow filtering PRs based on merged dates and base branch.

### Implementation
The changes allow users to specify tags for previous and current releases, enabling the retrieval of PRs between any two releases instead of just the latest. The `githubClient` now supports additional filters for merged PRs, and the core logic in `relgen` has been updated to accommodate these new options.

### Other Notes
The implementation includes a TODO to enhance the output by including labels for PRs and comments for issues.