### PR TITLE
feat: config

### DIFF
--- a/apps/relgen/examples/.relgen.json
+++ b/apps/relgen/examples/.relgen.json
@@ -1,0 +1,15 @@
+{
+  "llm": {
+    "provider": "anthropic",
+    "model": "claude-3-opus-latest",
+    "apiKey": "your-anthropic-api-key-here"
+  },
+  "integrations": {
+    "github": {
+      "token": "your-github-token-here"
+    },
+    "linear": {
+      "token": "your-linear-token-here"
+    }
+  }
+}

--- a/apps/relgen/examples/.relgen.json
+++ b/apps/relgen/examples/.relgen.json
@@ -1,8 +1,8 @@
 {
   "llm": {
-    "provider": "anthropic",
-    "model": "claude-3-opus-latest",
-    "apiKey": "your-anthropic-api-key-here"
+    "provider": "openai",
+    "model": "gpt-4o-mini",
+    "apiKey": "your-openai-api-key-here"
   },
   "integrations": {
     "github": {

--- a/apps/relgen/package.json
+++ b/apps/relgen/package.json
@@ -24,7 +24,8 @@
     "pino": "^9.5.0",
     "pino-pretty": "^13.0.0",
     "radashi": "^12.3.0",
-    "relgen-core": "workspace:*"
+    "relgen-core": "workspace:*",
+    "zod": "^3.24.1"
   },
   "files": [
     "dist"

--- a/apps/relgen/src/config/schema.ts
+++ b/apps/relgen/src/config/schema.ts
@@ -1,0 +1,74 @@
+import { z } from 'zod';
+
+export const providerChoices = ['openai', 'anthropic'] as const;
+export const openaiModelChoices = [
+  'o1-preview',
+  'o1-mini',
+  'gpt-4o',
+  'gpt-4o-2024-05-13',
+  'gpt-4o-2024-08-06',
+  'gpt-4o-2024-11-20',
+  'gpt-4o-audio-preview',
+  'gpt-4o-audio-preview-2024-10-01',
+  'gpt-4o-mini',
+  'gpt-4o-mini',
+] as const;
+export const anthropicModelChoices = [
+  'claude-3-5-sonnet-latest',
+  'claude-3-5-sonnet-20241022',
+  'claude-3-5-sonnet-20240620',
+  'claude-3-5-haiku-latest',
+  'claude-3-5-haiku-20241022',
+  'claude-3-opus-latest',
+  'claude-3-opus-20240229',
+  'claude-3-sonnet-20240229',
+  'claude-3-haiku-20240307',
+] as const;
+
+export const providerModels = {
+  openai: openaiModelChoices,
+  anthropic: anthropicModelChoices,
+} as const;
+
+// from https://github.com/colinhacks/zod/discussions/2790
+function unionOfLiterals<T extends string | number>(constants: readonly T[]) {
+  const literals = constants.map((x) => z.literal(x)) as unknown as readonly [
+    z.ZodLiteral<T>,
+    z.ZodLiteral<T>,
+    ...z.ZodLiteral<T>[],
+  ];
+  return z.union(literals);
+}
+
+export const configSchema = z.object({
+  llm: z
+    .union([
+      z.object({
+        provider: z.literal('openai'),
+        model: unionOfLiterals(openaiModelChoices),
+        apiKey: z.string().optional(),
+      }),
+      z.object({
+        provider: z.literal('anthropic'),
+        model: unionOfLiterals(anthropicModelChoices),
+        apiKey: z.string().optional(),
+      }),
+    ])
+    .optional(),
+  integrations: z
+    .object({
+      github: z
+        .object({
+          token: z.string(),
+        })
+        .optional(),
+      linear: z
+        .object({
+          token: z.string(),
+        })
+        .optional(),
+    })
+    .optional(),
+});
+
+export type Config = z.infer<typeof configSchema>;

--- a/apps/relgen/src/config/schema.ts
+++ b/apps/relgen/src/config/schema.ts
@@ -11,7 +11,6 @@ export const openaiModelChoices = [
   'gpt-4o-audio-preview',
   'gpt-4o-audio-preview-2024-10-01',
   'gpt-4o-mini',
-  'gpt-4o-mini',
 ] as const;
 export const anthropicModelChoices = [
   'claude-3-5-sonnet-latest',

--- a/apps/relgen/src/index.ts
+++ b/apps/relgen/src/index.ts
@@ -40,7 +40,11 @@ const cli = program
   .option('-t, --llm-token <token>', 'llm token')
   .option('-s, --silent', 'do not print output')
   .option('-c, --config <config>', 'config file')
-  .option('-v, --verbose', 'verbose output (debug statements)')
+  .addOption(
+    new Option('-v, --verbose', 'verbose output (debug statements)').conflicts(
+      'silent'
+    )
+  )
   .addOption(
     new Option('-p, --provider <provider>', 'llm provider').choices(
       providerChoices

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -57,6 +57,9 @@ importers:
       relgen-core:
         specifier: workspace:*
         version: link:../../packages/relgen-core
+      zod:
+        specifier: ^3.24.1
+        version: 3.24.1
     devDependencies:
       '@repo/typescript-config':
         specifier: workspace:*


### PR DESCRIPTION
### Changes
This pull request introduces a new configuration file `.relgen.json` for managing LLM (Large Language Model) settings and integrations. It also updates the `package.json` to include the `zod` library for schema validation and modifies the `schema.ts` to define a configuration schema using Zod. Additionally, the `index.ts` file is updated to read from the configuration file and handle LLM provider and model selection more dynamically.

### Implementation
The new `.relgen.json` file allows users to specify their LLM provider (OpenAI or Anthropic), model, and API keys for integrations with GitHub and Linear. The `schema.ts` file defines the structure of this configuration using Zod, ensuring that the provided values conform to expected types. The `index.ts` file has been refactored to utilize this configuration, allowing for more flexible command-line options and improved user experience when selecting providers and models.