### PR TITLE
fix: resolve github token in the correct order

### DIFF
--- a/apps/relgen/src/index.ts
+++ b/apps/relgen/src/index.ts
@@ -149,8 +149,8 @@ const remote = cli
 
     githubToken =
       githubToken ||
-      configFile?.integrations?.github?.token ||
       process.env.GH_TOKEN ||
+      configFile?.integrations?.github?.token ||
       (await password({
         message: 'Enter GitHub token',
       }));


### PR DESCRIPTION
### Changes
The order of resolving the GitHub token has been modified to ensure it is retrieved correctly.

### Implementation
The code now first checks for the GitHub token in the configuration file and environment variable before prompting the user for input. This change improves the token resolution process by prioritizing existing tokens over user input.

### Other Notes
No unrelated changes were made in this pull request.