### PR TITLE
fix: rename github token env var

### DIFF
--- a/.changeset/metal-bats-look.md
+++ b/.changeset/metal-bats-look.md
@@ -1,0 +1,5 @@
+---
+"relgen": patch
+---
+
+renamed GH_TOKEN to GITHUB_TOKEN env var

--- a/apps/relgen/src/index.ts
+++ b/apps/relgen/src/index.ts
@@ -149,7 +149,7 @@ const remote = cli
 
     githubToken =
       githubToken ||
-      process.env.GH_TOKEN ||
+      process.env.GITHUB_TOKEN ||
       configFile?.integrations?.github?.token ||
       (await password({
         message: 'Enter GitHub token',


### PR DESCRIPTION
### Changes
- Renamed the environment variable from GH_TOKEN to GITHUB_TOKEN in the codebase.