### PR TITLE
chore: enable node 18 support

### DIFF
--- a/.changeset/nervous-suns-mix.md
+++ b/.changeset/nervous-suns-mix.md
@@ -1,0 +1,5 @@
+---
+"relgen": patch
+---
+
+enable node 18 support

--- a/apps/relgen/package.json
+++ b/apps/relgen/package.json
@@ -13,7 +13,7 @@
     "relgen": "dist/index.mjs"
   },
   "engines": {
-    "node": ">=20"
+    "node": ">=18"
   },
   "dependencies": {
     "@commander-js/extra-typings": "^12.1.0",
@@ -27,9 +27,7 @@
     "@relgen/core": "workspace:*",
     "zod": "^3.24.1"
   },
-  "files": [
-    "dist"
-  ],
+  "files": ["dist"],
   "devDependencies": {
     "@repo/typescript-config": "workspace:*",
     "@types/node": "^20.11.24",


### PR DESCRIPTION
### Changes
- Updated the Node.js engine requirement in package.json from version 20 to 18 to enable support for Node 18.

### Other Notes
- Adjusted the formatting of the "files" array in package.json for consistency.