### PR TITLE
security: remove npmrc with token

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,0 @@
-//registry.npmjs.org/:_authToken=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


### PR DESCRIPTION
not clear why a github action automation added this (the auth token is invalid) but it probably shouldn't be here